### PR TITLE
WIP: Refactor recipe for source installation with golang cookbook.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,8 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: centos-7.0
+  - name: centos-6.5
   - name: ubuntu-12.04
   - name: ubuntu-13.10
   - name: ubuntu-14.04

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Drone Cookbook Changelog
 =========================
 
+v0.5.0
+------
+* Refactor default recipe into separate source/package installations.
+* Add ChefSpec unit tests for recipes.
+
 v0.4.0
 ------
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rubocop'
 
 group :integration do
   gem 'serverspec'
+  gem 'chefspec'
   gem 'kitchen-vagrant'
   gem 'test-kitchen'
 end

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,9 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2014, Justin Campbell (<justin@justincampbell.me>)
+Copyright 2014, John Bellone (<jbellone@bloomberg.net>)
+Copyright 2014, Bloomberg Finance L.P.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,9 @@
-default['drone']['package_url'] = "http://downloads.drone.io/latest/drone.deb"
-default['drone']['temp_file'] = "/tmp/drone.deb"
+default['drone']['install_type'] = 'source'
+
+default['drone']['git_url'] = 'https://github.com/drone/drone.git'
+default['drone']['git_ref'] = 'v0.2.0'
+
+default['drone']['package_url'] = 'https://downloads.drone.io/latest/drone.deb'
 default['drone']['config_file'] = '/etc/init/drone.conf'
 default['drone']['droned_opts'] = '--port=:80'
 default['drone']['drone_tmp'] = '/tmp/drone'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,8 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'
 
 depends 'docker'
+depends 'golang'
 
+supports 'redhat', '>= 6.5'
+supports 'centos', '>= 6.5'
 supports 'ubuntu', '>= 12.04'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -1,0 +1,17 @@
+template 'drone.conf' do
+  source 'drone.conf.erb'
+  path node['drone']['config_file']
+  mode 0644
+  owner 'root'
+  group 'root'
+  variables(
+     droned_opts: node['drone']['droned_opts'],
+     drone_tmp:   node['drone']['drone_tmp']
+  )
+end
+
+service 'drone' do
+  supports status: true, restart: true
+  action [:enable, :start]
+  subscribes :restart, 'drone.conf', :immediately
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,33 +1,6 @@
-include_recipe "docker"
+include_recipe 'docker::default'
 
-remote_file node['drone']['temp_file'] do
-  source node['drone']['package_url']
-  action :create_if_missing
-end
+install_type = node['drone']['install_type']
+include_recipe "drone::install_#{install_type}"
 
-dpkg_package "drone" do
-  source node['drone']['temp_file']
-  action :install
-end
-
-template 'drone.conf' do
-  source 'drone.conf.erb'
-  path node['drone']['config_file']
-  mode 0644
-  owner 'root'
-  group 'root'
-  variables(
-     droned_opts: node['drone']['droned_opts'],
-     drone_tmp:   node['drone']['drone_tmp']
-  )
-
-  notifies :restart, "service[drone]", :delayed
-end
-
-service "drone" do
-  provider Chef::Provider::Service::Upstart
-  supports status: true, restart: true
-  action [:enable, :start]
-  restart_command 'service drone restart'
-  subscribes :restart, "drone.conf", :immediately
-end
+include_recipe 'drone::_service'

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -1,0 +1,4 @@
+package 'drone' do
+  source node['drone']['package_url'] if node['drone']['package_url']
+  version node['drone']['package_version'] if node['drone']['package_version']
+end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -1,0 +1,22 @@
+include_recipe 'golang::default'
+
+directory File.join(node['go']['gopath'], 'src/github.com/drone') do
+  owner 'root'
+  group 'root'
+  mode '00755'
+  recursive true
+end
+
+git File.join(node['go']['gopath'], '/src/github.com/drone/drone') do
+  repository node['drone']['git_url']
+  reference node['drone']['git_ref']
+  action :checkout
+end
+
+golang_package 'github.com/drone/drone' do
+  action :install
+end
+
+link File.join(node['drone']['install_dir'], 'drone') do
+  to File.join(node['go']['gobin'], 'drone')
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,37 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.color = true
+  config.alias_example_group_to :describe_recipe, type: :recipe
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  Kernel.srand config.seed
+  config.order = :random
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+    mocks.verify_partial_doubles = true
+  end
+end
+
+RSpec.shared_context 'recipe tests', type: :recipe do
+  let(:chef_run) { ChefSpec::Runner.new(node_attributes).converge(described_recipe) }
+
+  def node_attributes
+    {
+     platform: 'ubuntu',
+     version: '14.04'
+    }
+  end
+end

--- a/spec/unit/recipes/_service_spec.rb
+++ b/spec/unit/recipes/_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe_recipe 'drone::_service' do
+  it do
+    expect(chef_run).to create_template('drone.conf')
+      .with(source: 'drone.conf.erb')
+      .with(path: '/etc/init/drone.conf')
+      .with(mode: 0644)
+      .with(owner: 'root')
+      .with(group: 'root')
+      .with(variables: {
+        droned_opts: '--port=:80',
+        drone_tmp: '/tmp/drone'
+      })
+  end
+
+  it { expect(chef_run).to enable_service('drone') }
+  it { expect(chef_run).to start_service('drone') }
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe_recipe 'drone::default' do
+  it { expect(chef_run).to include_recipe('docker::default') }
+  it { expect(chef_run).to include_recipe('drone::_service') }
+
+  describe 'with default attributes' do
+    it { expect(chef_run).to include_recipe('drone::install_source')}
+  end
+
+  describe %Q(with node['drone']['install_type'] = 'package') do
+    let(:chef_run) do
+      ChefSpec::Runner.new(node_attributes) do |node|
+        node.set['drone']['install_type'] = 'package'
+      end.converge(described_recipe)
+    end
+
+    it { expect(chef_run).to include_recipe('drone::install_package') }
+  end
+end

--- a/spec/unit/recipes/install_package_spec.rb
+++ b/spec/unit/recipes/install_package_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe_recipe 'drone::install_package' do
+  it do
+    expect(chef_spec).to install_package('drone')
+      .with(source: 'http://downloads.drone.io/latest/drone.deb')
+  end
+end

--- a/spec/unit/recipes/install_source_spec.rb
+++ b/spec/unit/recipes/install_source_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe_recipe 'drone::install_source' do
+  before do
+    stub_command("/usr/local/go/bin/go version | grep \"go1.2 \"").and_return(false)
+  end
+
+  it { expect(chef_spec).to include_recipe('golang::default') }
+  it { expect(chef_run).to create_directory('/opt/go/src/github.com/drone') }
+  it { expect(chef_run).to checkout_git('/opt/go/src/github.com/drone/drone') }
+  it { expect(chef_run).to install_golang_package('github.com/drone/drone') }
+  it { expect(chef_run.link('/usr/local/bin/drone')).to link_to('/opt/go/bin/drone') }
+end


### PR DESCRIPTION
Please do _not_ merge yet!

This uses the golang cookbook to provide a source installation as well
as the original package installation. The only change to the package
installation is to use the native package resource for the operating
system instead of explicitly the dpkg_package resource.
