### PR TITLE
correct default download url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['drone']['package_url'] = "http://downloads.drone.io/latest/drone.deb"
+default['drone']['package_url'] = "http://downloads.drone.io/master/drone.deb"
 default['drone']['temp_file'] = "/tmp/drone.deb"
 default['drone']['config_file'] = '/etc/init/drone.conf'
 default['drone']['droned_opts'] = '--port=:80'


### PR DESCRIPTION
it will respond status 403 when using url `http://download.drone.io/latest/drone.deb`.
